### PR TITLE
Fix path handling for translation data save

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,13 @@
+import os
+from utils import save_translation_data, load_translation_data, create_sample_translation_data
+
+
+def test_save_translation_data_no_directory(tmp_path, monkeypatch):
+    # change to temporary directory
+    monkeypatch.chdir(tmp_path)
+    file_name = "translation_data.json"
+    data = create_sample_translation_data()
+    assert save_translation_data(data, file_name)
+    loaded = load_translation_data(file_name)
+    assert loaded and loaded[0]["id"] == "greeting_1"
+

--- a/utils.py
+++ b/utils.py
@@ -21,7 +21,9 @@ def load_translation_data(file_path: str) -> List[Dict[str, Any]]:
 def save_translation_data(data: List[Dict[str, Any]], file_path: str) -> bool:
     """Save translation data to a JSON file."""
     try:
-        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+        directory = os.path.dirname(file_path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
         with open(file_path, 'w', encoding='utf-8') as f:
             json.dump(data, f, ensure_ascii=False, indent=2)
         return True


### PR DESCRIPTION
## Summary
- avoid attempting to create a directory with an empty path in `save_translation_data`
- add unit test covering saving to a filename with no directory component

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68662d134ffc832d9cd964dcb9409731