### PR TITLE
Enhance language filtering

### DIFF
--- a/translation_rag/pipeline.py
+++ b/translation_rag/pipeline.py
@@ -110,10 +110,19 @@ class RAGPipeline:
 
         self.vectorstore.persist()
 
-    def query(self, question: str, use_rag: bool = True, k: int = 3) -> str:
-        """Query the pipeline."""
+    def query(
+        self,
+        question: str,
+        use_rag: bool = True,
+        k: int = 3,
+        metadata_filter: Optional[dict] = None,
+    ) -> str:
+        """Query the pipeline with optional metadata filtering."""
         if use_rag and self.vectorstore:
-            retriever = self.vectorstore.as_retriever(search_kwargs={"k": k})
+            search_kwargs = {"k": k}
+            if metadata_filter:
+                search_kwargs["filter"] = metadata_filter
+            retriever = self.vectorstore.as_retriever(search_kwargs=search_kwargs)
             qa_chain = RetrievalQA.from_chain_type(
                 llm=self.llm,
                 chain_type="stuff",

--- a/translation_rag/utils.py
+++ b/translation_rag/utils.py
@@ -3,6 +3,7 @@ import os
 import json
 from typing import List, Dict, Any, Optional
 from pathlib import Path
+from langdetect import detect, LangDetectException
 
 
 def load_translation_data(file_path: str) -> List[Dict[str, Any]]:
@@ -169,6 +170,14 @@ def get_supported_languages() -> Dict[str, str]:
         'ar': 'Arabic',
         'hi': 'Hindi'
     }
+
+
+def detect_language(text: str) -> str:
+    """Return ISO language code detected in the given text."""
+    try:
+        return detect(text)
+    except LangDetectException:
+        return "unknown"
 
 
 def clean_chroma_db(persist_directory: str = "./chroma_db") -> bool:


### PR DESCRIPTION
## Summary
- allow metadata filtering in pipeline queries
- encode languages as boolean flags to avoid complex metadata
- detect input language and filter retrieval to matching documents
- expose a `detect_language` helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68664ff8b0c8832d84d8ca684cbda300