### PR TITLE
Improve logging and suppress telemetry warnings

### DIFF
--- a/translation_rag/__main__.py
+++ b/translation_rag/__main__.py
@@ -1,4 +1,10 @@
 """CLI entry point for Translation RAG."""
+import warnings
+from requests.exceptions import RequestsDependencyWarning
+
+# Suppress warnings from the requests package before other imports
+warnings.filterwarnings("ignore", category=RequestsDependencyWarning)
+
 from .cli import main
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- suppress Requests warnings at startup
- disable Chroma telemetry and log retrieved docs
- use RetrievalQA.invoke instead of the deprecated run method

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68665d28f280832da489a378a45f4b56