### PR TITLE
Fix metadata filter for Chroma retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ python -m translation_rag "How do I politely decline a meeting in Spanish?"
 python -m translation_rag "Translate 'machine learning algorithm' to French"
 ```
 
+### Filtering by language pair
+```bash
+# Restrict retrieval to a specific source/target pair
+python -m translation_rag "How do you say 'thank you' in Italian?" --from en --to es
+```
+
 ### System Analysis
 ```bash
 # Show retrieval statistics

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -35,3 +35,15 @@ def test_pipeline_with_memory(tmp_path):
     texts, metas = memory_to_documents(load_fake_memory())
     pipeline.add_documents(texts, metas)
     assert pipeline.vectorstore is not None
+
+
+def test_build_filter_conversion():
+    multi = RAGPipeline._build_filter({"source_lang": "en", "target_lang": "es"})
+    assert multi == {
+        "$and": [
+            {"source_lang": {"$eq": "en"}},
+            {"target_lang": {"$eq": "es"}},
+        ]
+    }
+    single = RAGPipeline._build_filter({"lang_en": True})
+    assert single == {"lang_en": {"$eq": True}}


### PR DESCRIPTION
## Summary
- handle multi-field metadata filters for Chroma
- allow resetting Chroma when adding documents
- test filter conversion utility
- document usage of language pair filters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68666241920c832d846e1dc1a3ba88ed