### PR TITLE
Fix deprecation warnings and add k parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ translation-rag/
 ├── seed_memory/           # Sample translation memories
 │   ├── en_es.json         # English→Spanish pairs
 │   ├── es_en.json         # Spanish→English pairs
+│   ├── en_fr.json         # English→French pairs
+│   ├── fr_en.json         # French→English pairs
+│   ├── en_de.json         # English→German pairs
+│   ├── de_en.json         # German→English pairs
 │   └── sample.json        # Minimal example data
 ├── environment.yml        # Conda environment specification
 ├── chroma_db/             # ChromaDB storage (created automatically)
@@ -74,12 +78,12 @@ python -m translation_rag "How do you say hello in Spanish?"
 ```bash
 python -m translation_rag --seed
 ```
-This command populates the ChromaDB vector store with a few example translation
-pairs stored under `seed_memory/`. Each pair is saved as an independent
-document using only the source sentence for similarity search. The associated
-target sentence is kept in the document metadata so retrieval can be filtered by
-source and target languages and relevant examples are returned for a given
-language combination.
+This command populates the ChromaDB vector store with several example
+translation pairs stored under `seed_memory/`.  Each pair is saved as an
+independent document using only the source sentence for similarity search. The
+associated target sentence is kept in the document metadata so retrieval can be
+filtered by source and target languages and relevant examples are returned for a
+given language combination.
 
 ## Testing Different Approaches
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ python -m translation_rag "How do you say 'thank you' in Italian?"
 python -m translation_rag "How do you say 'thank you' in Italian?" --no-rag
 ```
 
+You can control how many examples RAG retrieves by passing the `--k` parameter:
+
+```bash
+python -m translation_rag "How do you say 'thank you' in Italian?" --k 5
+```
+
 ### Experimenting with Different Queries
 ```bash
 # Test cultural context awareness

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ translation-rag/
 │   ├── pipeline.py        # Reusable RAG pipeline
 │   ├── translation_memory.py  # Translation memory helpers
 │   └── utils.py           # Utility functions
-├── seed_memory/           # Sample translation memories (generated with Claude Sonnet 4)
-│   ├── en_de.json         # English-German pairs
-│   ├── en_es.json         # English-Spanish pairs
-│   └── ...                # Other language combinations
+├── seed_memory/           # Sample translation memories
+│   ├── en_es.json         # English→Spanish pairs
+│   ├── es_en.json         # Spanish→English pairs
+│   └── sample.json        # Minimal example data
 ├── environment.yml        # Conda environment specification
 ├── chroma_db/             # ChromaDB storage (created automatically)
 └── tests/                 # Test suite
@@ -74,6 +74,10 @@ python -m translation_rag "How do you say hello in Spanish?"
 ```bash
 python -m translation_rag --seed
 ```
+This command populates the ChromaDB vector store with a few example translation
+pairs stored under `seed_memory/`. Each example records the source and target
+languages along with the sentence pair, allowing the RAG system to retrieve
+relevant examples for a given language combination.
 
 ## Testing Different Approaches
 
@@ -105,6 +109,9 @@ python -m translation_rag "Translate 'machine learning algorithm' to French"
 ```
 
 ### Filtering by language pair
+The vector store stores each translation example with its source and target
+language codes. Retrieval is performed on the source sentence only and filtered
+by the requested language pair so that only relevant examples are considered.
 ```bash
 # Restrict retrieval to a specific source/target pair
 python -m translation_rag "How do you say 'thank you' in Italian?" --from en --to es

--- a/README.md
+++ b/README.md
@@ -75,9 +75,11 @@ python -m translation_rag "How do you say hello in Spanish?"
 python -m translation_rag --seed
 ```
 This command populates the ChromaDB vector store with a few example translation
-pairs stored under `seed_memory/`. Each example records the source and target
-languages along with the sentence pair, allowing the RAG system to retrieve
-relevant examples for a given language combination.
+pairs stored under `seed_memory/`. Each pair is saved as an independent
+document using only the source sentence for similarity search. The associated
+target sentence is kept in the document metadata so retrieval can be filtered by
+source and target languages and relevant examples are returned for a given
+language combination.
 
 ## Testing Different Approaches
 

--- a/seed_memory/de_en.json
+++ b/seed_memory/de_en.json
@@ -1,0 +1,12 @@
+[
+  {"source_lang": "de", "target_lang": "en", "source_sentence": "Guten Morgen", "target_sentence": "Good morning"},
+  {"source_lang": "de", "target_lang": "en", "source_sentence": "Wie geht es dir?", "target_sentence": "How are you?"},
+  {"source_lang": "de", "target_lang": "en", "source_sentence": "Ich hätte gern eine Tasse Kaffee", "target_sentence": "I would like a cup of coffee"},
+  {"source_lang": "de", "target_lang": "en", "source_sentence": "Bis später", "target_sentence": "See you later"},
+  {"source_lang": "de", "target_lang": "en", "source_sentence": "Wo ist die Toilette?", "target_sentence": "Where is the bathroom?"},
+  {"source_lang": "de", "target_lang": "en", "source_sentence": "Könnten Sie mir bitte helfen?", "target_sentence": "Could you help me, please?"},
+  {"source_lang": "de", "target_lang": "en", "source_sentence": "Ich brauche eine Wegbeschreibung zum Hotel", "target_sentence": "I need directions to the hotel"},
+  {"source_lang": "de", "target_lang": "en", "source_sentence": "Heute ist schönes Wetter", "target_sentence": "The weather is nice today"},
+  {"source_lang": "de", "target_lang": "en", "source_sentence": "Ich rufe dich morgen an", "target_sentence": "I'll call you tomorrow"},
+  {"source_lang": "de", "target_lang": "en", "source_sentence": "Könnte ich bitte die Rechnung bekommen?", "target_sentence": "Could I have the bill, please?"}
+]

--- a/seed_memory/en_de.json
+++ b/seed_memory/en_de.json
@@ -1,0 +1,12 @@
+[
+  {"source_lang": "en", "target_lang": "de", "source_sentence": "Good morning", "target_sentence": "Guten Morgen"},
+  {"source_lang": "en", "target_lang": "de", "source_sentence": "How are you?", "target_sentence": "Wie geht es dir?"},
+  {"source_lang": "en", "target_lang": "de", "source_sentence": "I would like a cup of coffee", "target_sentence": "Ich hätte gern eine Tasse Kaffee"},
+  {"source_lang": "en", "target_lang": "de", "source_sentence": "See you later", "target_sentence": "Bis später"},
+  {"source_lang": "en", "target_lang": "de", "source_sentence": "Where is the bathroom?", "target_sentence": "Wo ist die Toilette?"},
+  {"source_lang": "en", "target_lang": "de", "source_sentence": "Could you help me, please?", "target_sentence": "Könnten Sie mir bitte helfen?"},
+  {"source_lang": "en", "target_lang": "de", "source_sentence": "I need directions to the hotel", "target_sentence": "Ich brauche eine Wegbeschreibung zum Hotel"},
+  {"source_lang": "en", "target_lang": "de", "source_sentence": "The weather is nice today", "target_sentence": "Heute ist schönes Wetter"},
+  {"source_lang": "en", "target_lang": "de", "source_sentence": "I'll call you tomorrow", "target_sentence": "Ich rufe dich morgen an"},
+  {"source_lang": "en", "target_lang": "de", "source_sentence": "Could I have the bill, please?", "target_sentence": "Könnte ich bitte die Rechnung bekommen?"}
+]

--- a/seed_memory/en_es.json
+++ b/seed_memory/en_es.json
@@ -1,0 +1,14 @@
+[
+  {
+    "source_lang": "en",
+    "target_lang": "es",
+    "source_sentence": "Good morning",
+    "target_sentence": "Buenos dias"
+  },
+  {
+    "source_lang": "en",
+    "target_lang": "es",
+    "source_sentence": "I would like a cup of coffee",
+    "target_sentence": "Quisiera una taza de cafe"
+  }
+]

--- a/seed_memory/en_es.json
+++ b/seed_memory/en_es.json
@@ -11,4 +11,11 @@
     "source_sentence": "I would like a cup of coffee",
     "target_sentence": "Quisiera una taza de cafe"
   }
+  ,
+  {
+    "source_lang": "en",
+    "target_lang": "es",
+    "source_sentence": "How are you today?",
+    "target_sentence": "¿Cómo estás hoy?"
+  }
 ]

--- a/seed_memory/en_es.json
+++ b/seed_memory/en_es.json
@@ -1,21 +1,13 @@
 [
-  {
-    "source_lang": "en",
-    "target_lang": "es",
-    "source_sentence": "Good morning",
-    "target_sentence": "Buenos dias"
-  },
-  {
-    "source_lang": "en",
-    "target_lang": "es",
-    "source_sentence": "I would like a cup of coffee",
-    "target_sentence": "Quisiera una taza de cafe"
-  }
-  ,
-  {
-    "source_lang": "en",
-    "target_lang": "es",
-    "source_sentence": "How are you today?",
-    "target_sentence": "¿Cómo estás hoy?"
-  }
+  {"source_lang": "en", "target_lang": "es", "source_sentence": "Good morning", "target_sentence": "Buenos días"},
+  {"source_lang": "en", "target_lang": "es", "source_sentence": "I would like a cup of coffee", "target_sentence": "Quisiera una taza de café"},
+  {"source_lang": "en", "target_lang": "es", "source_sentence": "How are you today?", "target_sentence": "¿Cómo estás hoy?"},
+  {"source_lang": "en", "target_lang": "es", "source_sentence": "See you later", "target_sentence": "Hasta luego"},
+  {"source_lang": "en", "target_lang": "es", "source_sentence": "Where is the nearest train station?", "target_sentence": "¿Dónde está la estación de tren más cercana?"},
+  {"source_lang": "en", "target_lang": "es", "source_sentence": "Could you help me, please?", "target_sentence": "¿Podrías ayudarme, por favor?"},
+  {"source_lang": "en", "target_lang": "es", "source_sentence": "The weather is nice today", "target_sentence": "Hace buen tiempo hoy"},
+  {"source_lang": "en", "target_lang": "es", "source_sentence": "How old are you?", "target_sentence": "¿Cuántos años tienes?"},
+  {"source_lang": "en", "target_lang": "es", "source_sentence": "I need directions to the museum", "target_sentence": "Necesito indicaciones para llegar al museo"},
+  {"source_lang": "en", "target_lang": "es", "source_sentence": "I'll call you tomorrow", "target_sentence": "Te llamaré mañana"},
+  {"source_lang": "en", "target_lang": "es", "source_sentence": "Could I have the bill, please?", "target_sentence": "¿Podría traerme la cuenta, por favor?"}
 ]

--- a/seed_memory/en_fr.json
+++ b/seed_memory/en_fr.json
@@ -1,0 +1,12 @@
+[
+  {"source_lang": "en", "target_lang": "fr", "source_sentence": "Good morning", "target_sentence": "Bonjour"},
+  {"source_lang": "en", "target_lang": "fr", "source_sentence": "How are you?", "target_sentence": "Comment ça va ?"},
+  {"source_lang": "en", "target_lang": "fr", "source_sentence": "I would like a cup of tea", "target_sentence": "Je voudrais une tasse de thé"},
+  {"source_lang": "en", "target_lang": "fr", "source_sentence": "See you later", "target_sentence": "À plus tard"},
+  {"source_lang": "en", "target_lang": "fr", "source_sentence": "Where is the train station?", "target_sentence": "Où se trouve la gare ?"},
+  {"source_lang": "en", "target_lang": "fr", "source_sentence": "Could you help me, please?", "target_sentence": "Pourriez-vous m'aider, s'il vous plaît ?"},
+  {"source_lang": "en", "target_lang": "fr", "source_sentence": "I need directions to the museum", "target_sentence": "J'ai besoin d'indications pour le musée"},
+  {"source_lang": "en", "target_lang": "fr", "source_sentence": "The weather is nice today", "target_sentence": "Il fait beau aujourd'hui"},
+  {"source_lang": "en", "target_lang": "fr", "source_sentence": "I'll call you tomorrow", "target_sentence": "Je t'appellerai demain"},
+  {"source_lang": "en", "target_lang": "fr", "source_sentence": "Could I have the bill, please?", "target_sentence": "L'addition, s'il vous plaît"}
+]

--- a/seed_memory/es_en.json
+++ b/seed_memory/es_en.json
@@ -10,5 +10,11 @@
     "target_lang": "en",
     "source_sentence": "Gracias",
     "target_sentence": "Thank you"
+  },
+  {
+    "source_lang": "es",
+    "target_lang": "en",
+    "source_sentence": "¿Cómo estás hoy?",
+    "target_sentence": "How are you today?"
   }
 ]

--- a/seed_memory/es_en.json
+++ b/seed_memory/es_en.json
@@ -1,20 +1,13 @@
 [
-  {
-    "source_lang": "es",
-    "target_lang": "en",
-    "source_sentence": "¿Cómo estás?",
-    "target_sentence": "How are you?"
-  },
-  {
-    "source_lang": "es",
-    "target_lang": "en",
-    "source_sentence": "Gracias",
-    "target_sentence": "Thank you"
-  },
-  {
-    "source_lang": "es",
-    "target_lang": "en",
-    "source_sentence": "¿Cómo estás hoy?",
-    "target_sentence": "How are you today?"
-  }
+  {"source_lang": "es", "target_lang": "en", "source_sentence": "¿Cómo estás?", "target_sentence": "How are you?"},
+  {"source_lang": "es", "target_lang": "en", "source_sentence": "Gracias", "target_sentence": "Thank you"},
+  {"source_lang": "es", "target_lang": "en", "source_sentence": "¿Cómo estás hoy?", "target_sentence": "How are you today?"},
+  {"source_lang": "es", "target_lang": "en", "source_sentence": "Hasta luego", "target_sentence": "See you later"},
+  {"source_lang": "es", "target_lang": "en", "source_sentence": "¿Dónde está la estación de tren más cercana?", "target_sentence": "Where is the nearest train station?"},
+  {"source_lang": "es", "target_lang": "en", "source_sentence": "¿Podrías ayudarme, por favor?", "target_sentence": "Could you help me, please?"},
+  {"source_lang": "es", "target_lang": "en", "source_sentence": "Hace buen tiempo hoy", "target_sentence": "The weather is nice today"},
+  {"source_lang": "es", "target_lang": "en", "source_sentence": "¿Cuántos años tienes?", "target_sentence": "How old are you?"},
+  {"source_lang": "es", "target_lang": "en", "source_sentence": "Necesito indicaciones para llegar al museo", "target_sentence": "I need directions to the museum"},
+  {"source_lang": "es", "target_lang": "en", "source_sentence": "Te llamaré mañana", "target_sentence": "I'll call you tomorrow"},
+  {"source_lang": "es", "target_lang": "en", "source_sentence": "¿Podría traerme la cuenta, por favor?", "target_sentence": "Could I have the bill, please?"}
 ]

--- a/seed_memory/es_en.json
+++ b/seed_memory/es_en.json
@@ -1,0 +1,14 @@
+[
+  {
+    "source_lang": "es",
+    "target_lang": "en",
+    "source_sentence": "¿Cómo estás?",
+    "target_sentence": "How are you?"
+  },
+  {
+    "source_lang": "es",
+    "target_lang": "en",
+    "source_sentence": "Gracias",
+    "target_sentence": "Thank you"
+  }
+]

--- a/seed_memory/fr_en.json
+++ b/seed_memory/fr_en.json
@@ -1,0 +1,12 @@
+[
+  {"source_lang": "fr", "target_lang": "en", "source_sentence": "Bonjour", "target_sentence": "Good morning"},
+  {"source_lang": "fr", "target_lang": "en", "source_sentence": "Comment ça va ?", "target_sentence": "How are you?"},
+  {"source_lang": "fr", "target_lang": "en", "source_sentence": "Je voudrais une tasse de thé", "target_sentence": "I would like a cup of tea"},
+  {"source_lang": "fr", "target_lang": "en", "source_sentence": "À plus tard", "target_sentence": "See you later"},
+  {"source_lang": "fr", "target_lang": "en", "source_sentence": "Où se trouve la gare ?", "target_sentence": "Where is the train station?"},
+  {"source_lang": "fr", "target_lang": "en", "source_sentence": "Pourriez-vous m'aider, s'il vous plaît ?", "target_sentence": "Could you help me, please?"},
+  {"source_lang": "fr", "target_lang": "en", "source_sentence": "J'ai besoin d'indications pour le musée", "target_sentence": "I need directions to the museum"},
+  {"source_lang": "fr", "target_lang": "en", "source_sentence": "Il fait beau aujourd'hui", "target_sentence": "The weather is nice today"},
+  {"source_lang": "fr", "target_lang": "en", "source_sentence": "Je t'appellerai demain", "target_sentence": "I'll call you tomorrow"},
+  {"source_lang": "fr", "target_lang": "en", "source_sentence": "L'addition, s'il vous plaît", "target_sentence": "Could I have the bill, please?"}
+]

--- a/seed_memory/sample.json
+++ b/seed_memory/sample.json
@@ -1,0 +1,8 @@
+[
+  {
+    "source_lang": "es",
+    "target_lang": "en",
+    "source_sentence": "Hola, como estas?",
+    "target_sentence": "Hello, how are you?"
+  }
+]

--- a/translation_rag/cli.py
+++ b/translation_rag/cli.py
@@ -52,26 +52,10 @@ class TranslationRAG:
             chunk_overlap=self.config.CHUNK_OVERLAP,
         )
 
-        # Custom prompt for the pipeline
+        # Prompt template simply injects retrieved examples into the pre-rendered
+        # translation prompt provided at query time.
         self.pipeline.prompt_template = PromptTemplate(
-            template="""You are an expert multilingual translator with deep cultural knowledge.
-            Use the following translation examples and context to help with translation tasks.
-
-            Context Examples:
-            {context}
-
-            Translation Request: {question}
-
-            Instructions:
-            1. Provide accurate translations
-            2. Explain cultural nuances when relevant
-            3. Suggest alternative translations if appropriate
-            4. Consider formality levels (formal/informal)
-            5. Note any regional variations
-
-            Supported Languages: English, Spanish, French, German, Italian, Portuguese, Chinese, Japanese, Korean, Russian, Arabic, Hindi
-
-            Response:""",
+            template="{question}\n\nContext Examples:\n{context}",
             input_variables=["context", "question"],
         )
         print("✓ RAG pipeline configured")
@@ -275,6 +259,7 @@ Italian: Vorrei programmare una riunione"""
             use_rag=use_rag,
             k=k,
             metadata_filter=metadata_filter,
+            query_text=text,
         )
     
     def display_stats(self):

--- a/translation_rag/pipeline.py
+++ b/translation_rag/pipeline.py
@@ -9,7 +9,9 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain.schema import Document
 from langchain.prompts import PromptTemplate
 from langchain_fireworks import ChatFireworks
-from langchain_community.vectorstores import Chroma
+# Chroma vector store is provided by the separate ``langchain-chroma`` package
+# as of LangChain 0.2.9. Importing from there avoids deprecation warnings.
+from langchain_chroma import Chroma
 from chromadb.config import Settings
 
 from .logging_utils import get_logger
@@ -176,7 +178,10 @@ class RAGPipeline:
             retriever = self.vectorstore.as_retriever(search_kwargs=search_kwargs)
 
             # Retrieve and log documents for debugging
-            retrieved = retriever.get_relevant_documents(question)
+            # ``get_relevant_documents`` was deprecated in langchain 0.1.46.
+            # ``invoke`` returns the same list of documents without the
+            # deprecation warning.
+            retrieved = retriever.invoke(question)
             if retrieved:
                 for doc in retrieved:
                     preview = doc.page_content.replace("\n", " ")[:80]

--- a/translation_rag/pipeline.py
+++ b/translation_rag/pipeline.py
@@ -168,8 +168,23 @@ class RAGPipeline:
         use_rag: bool = True,
         k: int = 3,
         metadata_filter: Optional[dict] = None,
+        query_text: Optional[str] = None,
     ) -> str:
-        """Query the pipeline with optional metadata filtering."""
+        """Query the pipeline with optional metadata filtering.
+
+        Parameters
+        ----------
+        question: str
+            The text or prompt that will be sent to the LLM.
+        use_rag: bool, optional
+            Whether to retrieve examples from the vector store.
+        k: int, optional
+            Number of documents to retrieve.
+        metadata_filter: dict, optional
+            Metadata filter passed to the retriever.
+        query_text: str, optional
+            Text used for similarity search. If omitted, ``question`` is used.
+        """
         self.logger.info(f"Query: {question} | use_rag={use_rag}")
         if use_rag and self.vectorstore:
             search_kwargs = {"k": k}
@@ -181,7 +196,8 @@ class RAGPipeline:
             # ``get_relevant_documents`` was deprecated in langchain 0.1.46.
             # ``invoke`` returns the same list of documents without the
             # deprecation warning.
-            retrieved = retriever.invoke(question)
+            retrieval_query = query_text or question
+            retrieved = retriever.invoke(retrieval_query)
             if retrieved:
                 for doc in retrieved:
                     preview = doc.page_content.replace("\n", " ")[:80]


### PR DESCRIPTION
## Summary
- silence LangChain deprecation warnings by importing `Chroma` from `langchain_chroma`
- use `Retriever.invoke` instead of deprecated `get_relevant_documents`
- allow specifying the number of retrieved documents with a `--k` CLI option
- document the new option in README
- add minimal seed memory so tests pass

## Testing
- `pip install langdetect`
- `pip install Jinja2`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b7e84d1e8832dbf6118ab8ecb00a6