### PR TITLE
Add modular retrieval strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ python -m translation_rag "How do you say 'thank you' in Italian?"
 python -m translation_rag "How do you say 'thank you' in Italian?" --no-rag
 ```
 
+### Levenshtein Retrieval
+Use the classic Levenshtein distance instead of vector similarity:
+
+```bash
+python -m translation_rag "How do you say 'thank you' in Italian?" --levenshtein --from en --to it
+```
+
 You can control how many examples RAG retrieves by passing the `--k` parameter:
 
 ```bash

--- a/tests/test_translation_memory.py
+++ b/tests/test_translation_memory.py
@@ -3,6 +3,7 @@ from translation_rag.translation_memory import (
     load_fake_memory,
     memory_to_documents,
 )
+from translation_rag.strategies import LevenshteinRAG
 
 
 def test_basic_translation():
@@ -12,9 +13,25 @@ def test_basic_translation():
     assert "Hello" in result
 
 
+def test_levenshtein_retrieve():
+    tm = TranslationMemory()
+    tm.add_entries(load_fake_memory())
+    results = tm.retrieve_levenshtein("Hola, como estas?", "es", "en", k=1)
+    assert results
+    assert results[0].target_sentence
+
+
 def test_memory_to_documents():
     data = load_fake_memory()
     texts, metas = memory_to_documents(data)
     assert len(texts) == len(metas) == len(data)
     assert texts[0] == data[0]["source_sentence"]
     assert metas[0]["target_sentence"] == data[0]["target_sentence"]
+
+
+def test_levenshtein_strategy():
+    tm = TranslationMemory()
+    tm.add_entries(load_fake_memory())
+    strat = LevenshteinRAG(tm)
+    context = strat.get_context("Hola, como estas?", "es", "en", k=1)
+    assert context and "Hola" in context and "Hello" in context

--- a/translation_rag/strategies/__init__.py
+++ b/translation_rag/strategies/__init__.py
@@ -1,0 +1,13 @@
+"""Retrieval strategies for Translation RAG."""
+
+from .base import RAGStrategy
+from .levenshtein import LevenshteinRAG
+
+__all__ = ["RAGStrategy", "LevenshteinRAG", "SemanticRAG"]
+
+
+def __getattr__(name: str):
+    if name == "SemanticRAG":
+        from .semantic import SemanticRAG
+        return SemanticRAG
+    raise AttributeError(name)

--- a/translation_rag/strategies/base.py
+++ b/translation_rag/strategies/base.py
@@ -1,0 +1,15 @@
+"""Base interface for retrieval strategies."""
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+
+class RAGStrategy(ABC):
+    """Interface for building retrieval augmented strategies."""
+
+    @abstractmethod
+    def get_context(
+        self, text: str, source_lang: str, target_lang: str, k: int = 4
+    ) -> Optional[str]:
+        """Return contextual examples for the given text."""
+

--- a/translation_rag/strategies/levenshtein.py
+++ b/translation_rag/strategies/levenshtein.py
@@ -1,0 +1,21 @@
+"""Levenshtein distance based retrieval strategy."""
+
+from typing import Optional
+
+from ..translation_memory import TranslationMemory
+from .base import RAGStrategy
+
+
+class LevenshteinRAG(RAGStrategy):
+    """Retrieve context using edit distance similarity."""
+
+    def __init__(self, memory: TranslationMemory):
+        self.memory = memory
+
+    def get_context(
+        self, text: str, source_lang: str, target_lang: str, k: int = 4
+    ) -> Optional[str]:
+        entries = self.memory.retrieve_levenshtein(text, source_lang, target_lang, k=k)
+        if not entries:
+            return None
+        return "\n".join(f"{e.source_sentence} -> {e.target_sentence}" for e in entries)

--- a/translation_rag/strategies/semantic.py
+++ b/translation_rag/strategies/semantic.py
@@ -1,0 +1,63 @@
+"""Vector similarity based retrieval strategy."""
+
+from typing import Optional
+
+from ..config import Config
+from ..logging_utils import get_logger
+from ..pipeline import RAGPipeline
+from .base import RAGStrategy
+
+
+class SemanticRAG(RAGStrategy):
+    """Retrieve context using vector similarity search."""
+
+    def __init__(self, pipeline: RAGPipeline):
+        self.pipeline = pipeline
+        self.logger = get_logger()
+
+    def get_context(
+        self, text: str, source_lang: str, target_lang: str, k: int = 4
+    ) -> Optional[str]:
+        if not self.pipeline.vectorstore:
+            return None
+
+        metadata_filter = None
+        if source_lang != "unknown":
+            metadata_filter = {"source_lang": source_lang, "target_lang": target_lang}
+
+        filter_dict = (
+            self.pipeline._build_filter(metadata_filter) if metadata_filter else None
+        )
+        results_with_scores = self.pipeline.vectorstore.similarity_search_with_score(
+            text, k=k, filter=filter_dict
+        )
+        if not results_with_scores:
+            self.logger.info("No relevant documents retrieved")
+            return None
+
+        filtered = []
+        for i, (doc, score) in enumerate(results_with_scores):
+            similarity = 1 - score if score <= 1 else 0
+            preview = doc.page_content.replace("\n", " ")[:60]
+            self.logger.info(f"  [{i+1}] Similarity: {similarity:.3f} | {preview}...")
+            if similarity >= Config.SIMILARITY_THRESHOLD:
+                filtered.append(doc)
+            else:
+                self.logger.info(
+                    f"  ✗ Filtered out (below threshold {Config.SIMILARITY_THRESHOLD:.3f})"
+                )
+
+        if not filtered:
+            self.logger.info(
+                f"No documents above similarity threshold {Config.SIMILARITY_THRESHOLD:.3f}"
+            )
+            return None
+
+        context_parts = []
+        for doc in filtered:
+            tgt = doc.metadata.get("target_sentence")
+            if tgt:
+                context_parts.append(f"{doc.page_content} -> {tgt}")
+            else:
+                context_parts.append(doc.page_content)
+        return "\n".join(context_parts)


### PR DESCRIPTION
## Summary
- split retrieval methods into `strategies` package
- implement `SemanticRAG` and `LevenshteinRAG` classes
- refactor CLI to use the new strategy classes
- test Levenshtein strategy

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c24edc4f0832d8504e4106a4385b3