### PR TITLE
Log Levenshtein results

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ python -m translation_rag "How do you say 'thank you' in Italian?"
 python -m translation_rag "How do you say 'thank you' in Italian?" --no-rag
 ```
 
+### Levenshtein Retrieval
+Use the classic Levenshtein distance instead of vector similarity:
+
+```bash
+python -m translation_rag "How do you say 'thank you' in Italian?" --levenshtein --from en --to it
+```
+
 You can control how many examples RAG retrieves by passing the `--k` parameter:
 
 ```bash

--- a/tests/test_translation_memory.py
+++ b/tests/test_translation_memory.py
@@ -3,6 +3,7 @@ from translation_rag.translation_memory import (
     load_fake_memory,
     memory_to_documents,
 )
+from translation_rag.strategies import LevenshteinRAG
 
 
 def test_basic_translation():
@@ -12,9 +13,25 @@ def test_basic_translation():
     assert "Hello" in result
 
 
+def test_levenshtein_retrieve():
+    tm = TranslationMemory()
+    tm.add_entries(load_fake_memory())
+    results = tm.retrieve_levenshtein("Hola, como estas?", "es", "en", k=1)
+    assert results
+    assert results[0].target_sentence
+
+
 def test_memory_to_documents():
     data = load_fake_memory()
     texts, metas = memory_to_documents(data)
     assert len(texts) == len(metas) == len(data)
     assert texts[0] == data[0]["source_sentence"]
     assert metas[0]["target_sentence"] == data[0]["target_sentence"]
+
+
+def test_levenshtein_strategy():
+    tm = TranslationMemory()
+    tm.add_entries(load_fake_memory())
+    strat = LevenshteinRAG(tm)
+    context = strat.get_context("Hola, como estas?", "es", "en", k=1)
+    assert context and "Hola" in context and "Hello" in context

--- a/translation_rag/strategies/__init__.py
+++ b/translation_rag/strategies/__init__.py
@@ -1,0 +1,13 @@
+"""Retrieval strategies for Translation RAG."""
+
+from .base import RAGStrategy
+from .levenshtein import LevenshteinRAG
+
+__all__ = ["RAGStrategy", "LevenshteinRAG", "SemanticRAG"]
+
+
+def __getattr__(name: str):
+    if name == "SemanticRAG":
+        from .semantic import SemanticRAG
+        return SemanticRAG
+    raise AttributeError(name)

--- a/translation_rag/strategies/base.py
+++ b/translation_rag/strategies/base.py
@@ -1,0 +1,15 @@
+"""Base interface for retrieval strategies."""
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+
+class RAGStrategy(ABC):
+    """Interface for building retrieval augmented strategies."""
+
+    @abstractmethod
+    def get_context(
+        self, text: str, source_lang: str, target_lang: str, k: int = 4
+    ) -> Optional[str]:
+        """Return contextual examples for the given text."""
+

--- a/translation_rag/strategies/levenshtein.py
+++ b/translation_rag/strategies/levenshtein.py
@@ -1,0 +1,36 @@
+"""Levenshtein distance based retrieval strategy."""
+
+from typing import Optional
+
+from ..translation_memory import TranslationMemory
+from .base import RAGStrategy
+from ..logging_utils import get_logger
+
+
+class LevenshteinRAG(RAGStrategy):
+    """Retrieve context using edit distance similarity."""
+
+    def __init__(self, memory: TranslationMemory):
+        self.memory = memory
+        self.logger = get_logger()
+
+    def get_context(
+        self, text: str, source_lang: str, target_lang: str, k: int = 4
+    ) -> Optional[str]:
+        results = self.memory.retrieve_levenshtein(
+            text, source_lang, target_lang, k=k, return_scores=True
+        )
+        if not results:
+            self.logger.info("No relevant documents retrieved")
+            return None
+
+        self.logger.info(
+            f"Retrieved {len(results)} documents using Levenshtein search:"
+        )
+        context_parts = []
+        for i, (score, entry) in enumerate(results):
+            preview = entry.source_sentence.replace("\n", " ")[:60]
+            self.logger.info(f"  [{i+1}] Similarity: {score:.3f} | {preview}...")
+            context_parts.append(f"{entry.source_sentence} -> {entry.target_sentence}")
+
+        return "\n".join(context_parts)

--- a/translation_rag/strategies/semantic.py
+++ b/translation_rag/strategies/semantic.py
@@ -1,0 +1,63 @@
+"""Vector similarity based retrieval strategy."""
+
+from typing import Optional
+
+from ..config import Config
+from ..logging_utils import get_logger
+from ..pipeline import RAGPipeline
+from .base import RAGStrategy
+
+
+class SemanticRAG(RAGStrategy):
+    """Retrieve context using vector similarity search."""
+
+    def __init__(self, pipeline: RAGPipeline):
+        self.pipeline = pipeline
+        self.logger = get_logger()
+
+    def get_context(
+        self, text: str, source_lang: str, target_lang: str, k: int = 4
+    ) -> Optional[str]:
+        if not self.pipeline.vectorstore:
+            return None
+
+        metadata_filter = None
+        if source_lang != "unknown":
+            metadata_filter = {"source_lang": source_lang, "target_lang": target_lang}
+
+        filter_dict = (
+            self.pipeline._build_filter(metadata_filter) if metadata_filter else None
+        )
+        results_with_scores = self.pipeline.vectorstore.similarity_search_with_score(
+            text, k=k, filter=filter_dict
+        )
+        if not results_with_scores:
+            self.logger.info("No relevant documents retrieved")
+            return None
+
+        filtered = []
+        for i, (doc, score) in enumerate(results_with_scores):
+            similarity = 1 - score if score <= 1 else 0
+            preview = doc.page_content.replace("\n", " ")[:60]
+            self.logger.info(f"  [{i+1}] Similarity: {similarity:.3f} | {preview}...")
+            if similarity >= Config.SIMILARITY_THRESHOLD:
+                filtered.append(doc)
+            else:
+                self.logger.info(
+                    f"  ✗ Filtered out (below threshold {Config.SIMILARITY_THRESHOLD:.3f})"
+                )
+
+        if not filtered:
+            self.logger.info(
+                f"No documents above similarity threshold {Config.SIMILARITY_THRESHOLD:.3f}"
+            )
+            return None
+
+        context_parts = []
+        for doc in filtered:
+            tgt = doc.metadata.get("target_sentence")
+            if tgt:
+                context_parts.append(f"{doc.page_content} -> {tgt}")
+            else:
+                context_parts.append(doc.page_content)
+        return "\n".join(context_parts)

--- a/translation_rag/translation_memory.py
+++ b/translation_rag/translation_memory.py
@@ -4,6 +4,11 @@ from pathlib import Path
 from dataclasses import dataclass
 from typing import List, Iterable
 
+try:
+    from Levenshtein import distance as _fast_levenshtein
+except Exception:  # pragma: no cover - optional dependency
+    _fast_levenshtein = None
+
 
 def _tokens(text: str) -> set[str]:
     """Convert text to a set of lowercase word tokens."""
@@ -17,6 +22,39 @@ def _jaccard(a: set[str], b: set[str]) -> float:
     return len(a & b) / len(union)
 
 
+def _levenshtein(a: str, b: str) -> int:
+    """Compute Levenshtein edit distance."""
+    if _fast_levenshtein:
+        return _fast_levenshtein(a, b)
+
+    if a == b:
+        return 0
+    if not a:
+        return len(b)
+    if not b:
+        return len(a)
+
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, start=1):
+        curr = [i]
+        for j, cb in enumerate(b, start=1):
+            ins = prev[j] + 1
+            del_ = curr[j - 1] + 1
+            sub = prev[j - 1] + (ca != cb)
+            curr.append(min(ins, del_, sub))
+        prev = curr
+    return prev[-1]
+
+
+def _lev_similarity(a: str, b: str) -> float:
+    """Normalized similarity from Levenshtein distance."""
+    max_len = max(len(a), len(b))
+    if max_len == 0:
+        return 1.0
+    dist = _levenshtein(a, b)
+    return 1 - dist / max_len
+
+
 @dataclass
 class MemoryEntry:
     source_lang: str
@@ -24,10 +62,11 @@ class MemoryEntry:
     source_sentence: str
     target_sentence: str
     tokens: set[str]
+    lower_source: str
 
 
 class TranslationMemory:
-    """Simple translation memory using Jaccard similarity."""
+    """Simple translation memory supporting Jaccard and Levenshtein retrieval."""
 
     def __init__(self):
         self.entries: List[MemoryEntry] = []
@@ -39,6 +78,7 @@ class TranslationMemory:
             source_sentence=source_sentence,
             target_sentence=target_sentence,
             tokens=_tokens(source_sentence),
+            lower_source=source_sentence.lower(),
         )
         self.entries.append(entry)
 
@@ -61,9 +101,53 @@ class TranslationMemory:
         scored.sort(key=lambda x: x[0], reverse=True)
         return [e for _, e in scored[:k]]
 
+    def retrieve_levenshtein(
+        self,
+        sentence: str,
+        source_lang: str,
+        target_lang: str,
+        k: int = 2,
+        *,
+        return_scores: bool = False,
+    ) -> list[MemoryEntry] | list[tuple[float, MemoryEntry]]:
+        """Retrieve entries using Levenshtein similarity.
+
+        Parameters
+        ----------
+        sentence: str
+            The query sentence.
+        source_lang: str
+            Source language code.
+        target_lang: str
+            Target language code.
+        k: int, optional
+            Number of entries to return.
+        return_scores: bool, optional
+            If ``True`` return ``(score, entry)`` tuples instead of just
+            entries.
+        """
+
+        scored: list[tuple[float, MemoryEntry]] = []
+        for entry in self.entries:
+            if entry.source_lang == source_lang and entry.target_lang == target_lang:
+                sim = _lev_similarity(sentence.lower(), entry.lower_source)
+                scored.append((sim, entry))
+        scored.sort(key=lambda x: x[0], reverse=True)
+        results = scored[:k]
+        if return_scores:
+            return results
+        return [e for _, e in results]
+
     def translate_sentence(self, sentence: str, source_lang: str, target_lang: str) -> str:
         matches = self.retrieve(sentence, source_lang, target_lang, k=1)
         if matches and matches[0].tokens:
+            return matches[0].target_sentence
+        return f"[no translation for: {sentence.strip()}]"
+
+    def translate_sentence_levenshtein(self, sentence: str, source_lang: str, target_lang: str) -> str:
+        """Translate using Levenshtein retrieval."""
+        matches = self.retrieve_levenshtein(sentence, source_lang, target_lang, k=1)
+        if matches:
             return matches[0].target_sentence
         return f"[no translation for: {sentence.strip()}]"
 
@@ -74,6 +158,16 @@ class TranslationMemory:
             if not sent:
                 continue
             translated.append(self.translate_sentence(sent, source_lang, target_lang))
+        return " ".join(translated)
+
+    def translate_text_levenshtein(self, text: str, source_lang: str, target_lang: str) -> str:
+        """Translate text using Levenshtein retrieval."""
+        sentences = re.split(r"(?<=[.!?])\s+", text.strip())
+        translated = []
+        for sent in sentences:
+            if not sent:
+                continue
+            translated.append(self.translate_sentence_levenshtein(sent, source_lang, target_lang))
         return " ".join(translated)
 
 # Seed data lives in the repository root


### PR DESCRIPTION
## Summary
- extend translation memory retrieval to optionally return scores
- log retrieved entries in the Levenshtein strategy
- update strategy to display similarity metrics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c24edc4f0832d8504e4106a4385b3